### PR TITLE
Fix recursion in `rustc_link_search!(…)`

### DIFF
--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -193,6 +193,6 @@ macro_rules! rustc_link_search {
         $crate::pair!("rustc-link-search", "{}={}", $kind, $path);
     };
     ($($path:expr $(=> $kind:expr)?),+ $(,)?) => { {
-        $($crate::rustc_link_lib!($path $(=> $kind)?);)+
+        $($crate::rustc_link_search!($path $(=> $kind)?);)+
     } };
 }


### PR DESCRIPTION
The recursive arm of `rustc_link_search!(…)` was incorrectly calling `rustc_link_lib!(…)`.