### PR TITLE
Add support for `cargo:rustc-link-arg…` directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog] and this project adheres to
 
 - 40 snapshot tests (using [insta](https://crates.io/crates/insta))
 - Optional `to:` parameter for writing into a `std::fmt::Write` or `io::fmt::Write`.
+- `rustc_link_arg!($arg)` macro equivalent to `cargo:rustc-link-arg=$arg`
+- `rustc_link_arg_bin!($bin => $arg)` macro equivalent to `cargo:rustc-link-arg-bin=$bin=$arg`
+- `rustc_link_arg_bins!($arg)` macro equivalent to `cargo:rustc-link-arg-bins=$arg`
 
 # Removed
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ This crate exposes the following macros:
 | [`rustc_flags!($flags)`]               | `cargo:rustc-flags=$flags`            |
 | [`rustc_link_arg!($arg)`]              | `cargo:rustc-link-arg=$arg`           |
 | [`rustc_link_arg_bin!($bin => $arg)`]  | `cargo:rustc-link-arg-bin=$bin=$arg`  |
+| [`rustc_link_arg_bins!($arg)`]         | `cargo:rustc-link-arg-bins=$arg`      |
+| [`rustc_link_arg_bin!($bin => $arg)`]  | `cargo:rustc-link-arg-bin=$bin=$arg`  |
 | [`rustc_link_lib!($name => $kind)`]    | `cargo:rustc-link-lib=$kind=$name`    |
 | [`rustc_link_search!($path => $kind)`] | `cargo:rustc-link-search=$kind=$path` |
 | [`warning!($message)`]                 | `cargo:warning=$message`              |
@@ -69,6 +71,8 @@ This crate exposes the following macros:
 [`rustc_env!($key, $value)`]:             https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_env.html
 [`rustc_flags!($flags)`]:           https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_flags.html
 [`rustc_link_arg!($arg)`]:        https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_link_arg.html
+[`rustc_link_arg_bin!($bin => $arg)`]:    https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_link_arg_bin.html
+[`rustc_link_arg_bins!($arg)`]:   https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_link_arg_bins.html
 [`rustc_link_arg_bin!($bin => $arg)`]:    https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_link_arg_bin.html
 [`rustc_link_lib!($name => $kind)`]:        https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_link_lib.html
 [`rustc_link_search!($path => $kind)`]:     https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_link_search.html

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This crate exposes the following macros:
 | [`rustc_env!($key, $value)`]           | `cargo:rustc-env=$key=$value`         |
 | [`rustc_flags!($flags)`]               | `cargo:rustc-flags=$flags`            |
 | [`rustc_link_arg!($arg)`]              | `cargo:rustc-link-arg=$arg`           |
+| [`rustc_link_arg_bin!($bin => $arg)`]  | `cargo:rustc-link-arg-bin=$bin=$arg`  |
 | [`rustc_link_lib!($name => $kind)`]    | `cargo:rustc-link-lib=$kind=$name`    |
 | [`rustc_link_search!($path => $kind)`] | `cargo:rustc-link-search=$kind=$path` |
 | [`warning!($message)`]                 | `cargo:warning=$message`              |
@@ -68,6 +69,7 @@ This crate exposes the following macros:
 [`rustc_env!($key, $value)`]:             https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_env.html
 [`rustc_flags!($flags)`]:           https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_flags.html
 [`rustc_link_arg!($arg)`]:        https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_link_arg.html
+[`rustc_link_arg_bin!($bin => $arg)`]:    https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_link_arg_bin.html
 [`rustc_link_lib!($name => $kind)`]:        https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_link_lib.html
 [`rustc_link_search!($path => $kind)`]:     https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_link_search.html
 [`warning!($message)`]:               https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.warning.html

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This crate exposes the following macros:
 | [`rustc_cfg!($feature)`]               | `cargo:rustc-cfg=$feature`            |
 | [`rustc_env!($key, $value)`]           | `cargo:rustc-env=$key=$value`         |
 | [`rustc_flags!($flags)`]               | `cargo:rustc-flags=$flags`            |
+| [`rustc_link_arg!($arg)`]              | `cargo:rustc-link-arg=$arg`           |
 | [`rustc_link_lib!($name => $kind)`]    | `cargo:rustc-link-lib=$kind=$name`    |
 | [`rustc_link_search!($path => $kind)`] | `cargo:rustc-link-search=$kind=$path` |
 | [`warning!($message)`]                 | `cargo:warning=$message`              |
@@ -66,6 +67,7 @@ This crate exposes the following macros:
 [`rustc_cfg!($feature)`]:             https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_cfg.html
 [`rustc_env!($key, $value)`]:             https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_env.html
 [`rustc_flags!($flags)`]:           https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_flags.html
+[`rustc_link_arg!($arg)`]:        https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_link_arg.html
 [`rustc_link_lib!($name => $kind)`]:        https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_link_lib.html
 [`rustc_link_search!($path => $kind)`]:     https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.rustc_link_search.html
 [`warning!($message)`]:               https://docs.rs/cargo-emit/0.1.0/cargo_emit/macro.warning.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ mod rustc_cfg;
 mod rustc_env;
 mod rustc_flags;
 mod rustc_link_arg;
+mod rustc_link_arg_bin;
 mod rustc_link_lib;
 mod rustc_link_search;
 mod warning;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ mod rustc_env;
 mod rustc_flags;
 mod rustc_link_arg;
 mod rustc_link_arg_bin;
+mod rustc_link_arg_bins;
 mod rustc_link_lib;
 mod rustc_link_search;
 mod warning;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ mod rustc_cdylib_link_arg;
 mod rustc_cfg;
 mod rustc_env;
 mod rustc_flags;
+mod rustc_link_arg;
 mod rustc_link_lib;
 mod rustc_link_search;
 mod warning;

--- a/src/rustc_link_arg.rs
+++ b/src/rustc_link_arg.rs
@@ -1,0 +1,79 @@
+/// Tells Cargo to pass the -C link-arg=FLAG option to the compiler,
+/// but only when building supported targets (benchmarks, binaries, cdylib crates, examples, and tests).
+/// Its usage is highly platform specific.
+/// It is useful to set the shared library version or linker script.
+///
+/// This is equivalent to:
+///
+/// ```
+/// println!("cargo:rustc-link-arg=$flag");
+/// ```
+///
+/// # Examples
+///
+/// ```
+/// let flag1 = // ...
+/// # "";
+/// let flag2 = // ...
+/// # "";
+/// cargo_emit::rustc_link_arg!(
+///     flag1, flag2
+/// );
+/// ```
+///
+/// or, in case you want it to emit to a custom stream:
+///
+/// ```
+/// let flag1 = // ...
+/// # "";
+/// let flag2 = // ...
+/// # "";
+/// let mut stdout = std::io::stdout();
+/// cargo_emit::rustc_link_arg!(
+///     to: stdout,
+///     flag1, flag2
+/// );
+/// ```
+#[macro_export]
+macro_rules! rustc_link_arg {
+    (to: $stream:expr, $($flag:expr),+ $(,)?) => {
+        $($crate::pair!(to: $stream, "rustc-link-arg", "{}", $flag);)+
+    };
+    ($($flag:expr),+ $(,)?) => {
+        $crate::rustc_link_arg!(to: std::io::stdout(), $($flag),+);
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn single() {
+        insta::assert_display_snapshot!(
+            crate::capture_output(|output| {
+                crate::rustc_link_arg!(
+                    to: output,
+                    "ARG"
+                );
+            }),
+            @"cargo:rustc-link-arg=ARG
+        "
+        );
+    }
+
+    #[test]
+    fn multiple() {
+        insta::assert_display_snapshot!(
+            crate::capture_output(|output| {
+                crate::rustc_link_arg!(
+                    to: output,
+                    "ARG1",
+                    "ARG2"
+                );
+            }),
+            @r###"
+        cargo:rustc-link-arg=ARG1
+        cargo:rustc-link-arg=ARG2
+        "###
+        );
+    }
+}

--- a/src/rustc_link_arg_bin.rs
+++ b/src/rustc_link_arg_bin.rs
@@ -1,0 +1,77 @@
+/// Tells Cargo to pass the `-C link-arg=$flag` option to the compiler,
+/// but only when building the binary target with name `$bin`.
+/// Its usage is highly platform specific.
+/// It is useful to set a linker script or other linker options.
+///
+/// This is equivalent to:
+///
+/// ```
+/// println!("cargo:rustc-link-arg-bin=$bin=$flag");
+/// ```
+///
+/// # Examples
+///
+/// ```
+/// cargo_emit::rustc_link_arg_bin!(
+///     "hello_world" => "-Wall"
+/// );
+/// ```
+///
+/// or, in case you want it to emit to a custom stream:
+///
+/// ```
+/// let mut stdout = std::io::stdout();
+/// cargo_emit::rustc_link_arg_bin!(
+///     to: stdout,
+///     "hello_world" => "-Wall"
+/// );
+/// ```
+#[macro_export]
+macro_rules! rustc_link_arg_bin {
+    (to: $stream:expr, $bin:expr => $flags:expr $(,)?) => {
+        $crate::pair!(to: $stream, "rustc-link-arg-bin", "{}={}", $bin, $flags);
+    };
+    (to: $stream:expr, $($bin:expr=> $flags:expr),+ $(,)?) => { {
+        $($crate::rustc_link_arg_bin!(to: $stream, $bin => $flags);)+
+    } };
+    ($bin:expr => $flags:expr $(,)?) => {
+        $crate::rustc_link_arg_bin!(to: std::io::stdout(), $bin => $flags);
+    };
+    ($($bin:expr=> $flags:expr),+ $(,)?) => { {
+        $crate::rustc_link_arg_bin!(to: std::io::stdout(), $($bin=> $flags),+);
+    } };
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn single() {
+        insta::assert_display_snapshot!(
+            crate::capture_output(|output| {
+                crate::rustc_link_arg_bin!(
+                    to: output,
+                    "BIN" => "FLAGS"
+                );
+            }),
+            @"cargo:rustc-link-arg-bin=BIN=FLAGS
+        "
+        );
+    }
+
+    #[test]
+    fn multiple() {
+        insta::assert_display_snapshot!(
+            crate::capture_output(|output| {
+                crate::rustc_link_arg_bin!(
+                    to: output,
+                    "BIN1" => "FLAGS1",
+                    "BIN2" => "FLAGS2",
+                );
+            }),
+            @r###"
+        cargo:rustc-link-arg-bin=BIN1=FLAGS1
+        cargo:rustc-link-arg-bin=BIN2=FLAGS2
+        "###
+        );
+    }
+}

--- a/src/rustc_link_arg_bins.rs
+++ b/src/rustc_link_arg_bins.rs
@@ -1,0 +1,79 @@
+/// Tells Cargo to pass the `-C link-arg=$flag` option to the compiler,
+/// but only when building a binary target.
+/// Its usage is highly platform specific.
+/// It is useful to set a linker script or other linker options.
+///
+/// This is equivalent to:
+///
+/// ```
+/// println!("cargo:rustc-link-arg-bins=$flag");
+/// ```
+///
+/// # Examples
+///
+/// ```
+/// let flag1 = // ...
+/// # "";
+/// let flag2 = // ...
+/// # "";
+/// cargo_emit::rustc_link_arg_bins!(
+///     flag1, flag2
+/// );
+/// ```
+///
+/// or, in case you want it to emit to a custom stream:
+///
+/// ```
+/// let flag1 = // ...
+/// # "";
+/// let flag2 = // ...
+/// # "";
+/// let mut stdout = std::io::stdout();
+/// cargo_emit::rustc_link_arg_bins!(
+///     to: stdout,
+///     flag1, flag2
+/// );
+/// ```
+#[macro_export]
+macro_rules! rustc_link_arg_bins {
+    (to: $stream:expr, $($flag:expr),+ $(,)?) => {
+        $($crate::pair!(to: $stream, "rustc-link-arg-bins", "{}", $flag);)+
+    };
+    ($($flag:expr),+ $(,)?) => {
+        $crate::rustc_link_arg_bins!(to: std::io::stdout(), $($flag),+);
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn single() {
+        insta::assert_display_snapshot!(
+            crate::capture_output(|output| {
+                crate::rustc_link_arg_bins!(
+                    to: output,
+                    "ARG"
+                );
+            }),
+            @"cargo:rustc-link-arg-bins=ARG
+        "
+        );
+    }
+
+    #[test]
+    fn multiple() {
+        insta::assert_display_snapshot!(
+            crate::capture_output(|output| {
+                crate::rustc_link_arg_bins!(
+                    to: output,
+                    "ARG1",
+                    "ARG2"
+                );
+            }),
+            @r###"
+        cargo:rustc-link-arg-bins=ARG1
+        cargo:rustc-link-arg-bins=ARG2
+        "###
+        );
+    }
+}


### PR DESCRIPTION
(depends on https://github.com/nvzqz/cargo-emit/pull/3)