### PR TITLE
Update dependency instructions for version 0.2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //!
 //! ```toml
 //! [build-dependencies]
-//! cargo-emit = "0.1"
+//! cargo-emit = "0.2"
 //! ```
 //!
 //! and something like this to your [`build.rs`]:


### PR DESCRIPTION
This PR changes the instructions in `lib.rs` to add version 0.2 instead of 0.1.