### PR TITLE
compare_and_set_contents_hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,9 @@ edition = "2018"
 
 [dev-dependencies]
 insta = "1.7.2"
+
+[dependencies]
+fxhash = { version = "0.2.1", optional = true }
+
+[features]
+compare_and_set_contents_hash = ["fxhash"]

--- a/src/convenience/compare_and_set_contents_hash.rs
+++ b/src/convenience/compare_and_set_contents_hash.rs
@@ -4,9 +4,13 @@ use fxhash::FxHasher;
 
 const CARGO_EMIT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// The result of comparing the contents of a file using its hash.
 pub enum HashFileOutcome {
+    /// A fresh "hash file" with the hashed contents of the file-argument has been created.
     Created,
+    /// Based on the "hash file", he contents of the file-argument have changed.
     Changed,
+    /// Based on the "hash file", the contents of the file-argument have not changed.
     Unchanged,
 }
 

--- a/src/convenience/compare_and_set_contents_hash.rs
+++ b/src/convenience/compare_and_set_contents_hash.rs
@@ -14,10 +14,17 @@ pub enum HashFileOutcome {
     Unchanged,
 }
 
-/// Check if the contents of a file have changed using its hash instead of its modification time.
+/// Check if the contents of a file have changed using its hash instead of its modification time. Currently,
+/// this function does not support directories. See <https://github.com/nvzqz/cargo-emit/pull/9>.
 pub fn compare_and_set_contents_hash(path: &str) -> HashFileOutcome {
     let computed_contents_hash: u64 = {
         let mut hasher = FxHasher::default();
+        if std::fs::metadata(path)
+            .expect(format!("failed to get metadata for '{}'", path).as_str())
+            .is_dir()
+        {
+            panic!("The current implementation does not support directories. See <https://github.com/nvzqz/cargo-emit/pull/9>");
+        }
         let file =
             std::fs::File::open(path).expect(format!("failed to open file at '{}'", path).as_str());
         let mut reader = std::io::BufReader::new(file);

--- a/src/convenience/compare_and_set_contents_hash.rs
+++ b/src/convenience/compare_and_set_contents_hash.rs
@@ -1,0 +1,59 @@
+use std::{hash::Hasher, io::Read};
+
+use fxhash::FxHasher;
+
+const CARGO_EMIT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub enum HashFileOutcome {
+    Created,
+    Changed,
+    Unchanged,
+}
+
+/// Check if the contents of a file have changed using its hash instead of its modification time.
+pub fn compare_and_set_contents_hash(path: &str) -> HashFileOutcome {
+    let computed_contents_hash: u64 = {
+        let mut hasher = FxHasher::default();
+        let file =
+            std::fs::File::open(path).expect(format!("failed to open file at '{}'", path).as_str());
+        let mut reader = std::io::BufReader::new(file);
+        hasher.write(CARGO_EMIT_VERSION.as_bytes());
+        let mut buffer = [0; 1024];
+        loop {
+            let bytes_read = reader.read(&mut buffer).expect("failed to read file");
+            if bytes_read == 0 {
+                break;
+            }
+            hasher.write(&buffer[..bytes_read]);
+        }
+        hasher.finish()
+    };
+
+    let path_hash: u64 = {
+        let mut hasher = FxHasher::default();
+        hasher.write(path.as_bytes());
+        hasher.finish()
+    };
+
+    let hash_file_name = format!("{:x}.hash", path_hash);
+    let out_dir = std::env::var("OUT_DIR")
+        .expect("failed to get OUT_DIR. Are you using the function in a build script?");
+    let hash_file_path = std::path::Path::new(&out_dir).join(hash_file_name);
+
+    if !hash_file_path.exists() {
+        std::fs::write(&hash_file_path, computed_contents_hash.to_ne_bytes())
+            .expect("failed to write hash file");
+        return HashFileOutcome::Created;
+    };
+
+    let stored_contents_hash = std::fs::read(&hash_file_path).expect("failed to read hash file");
+    assert!(stored_contents_hash.len() == computed_contents_hash.to_ne_bytes().len());
+
+    if stored_contents_hash == computed_contents_hash.to_ne_bytes() {
+        HashFileOutcome::Unchanged
+    } else {
+        std::fs::write(&hash_file_path, computed_contents_hash.to_ne_bytes())
+            .expect("failed to write hash file");
+        HashFileOutcome::Changed
+    }
+}

--- a/src/convenience/mod.rs
+++ b/src/convenience/mod.rs
@@ -1,0 +1,5 @@
+#[cfg(feature = "compare_and_set_contents_hash")]
+mod compare_and_set_contents_hash;
+
+#[cfg(feature = "compare_and_set_contents_hash")]
+pub use compare_and_set_contents_hash::compare_and_set_contents_hash;

--- a/src/convenience/mod.rs
+++ b/src/convenience/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "compare_and_set_contents_hash")]
-mod compare_and_set_contents_hash;
+/// Check if the contents of a file have changed using its hash instead of its modification time.
+pub mod compare_and_set_contents_hash;
 
 #[cfg(feature = "compare_and_set_contents_hash")]
 pub use compare_and_set_contents_hash::compare_and_set_contents_hash;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,9 @@ mod rustc_link_search;
 /// `cargo:warning=$message`
 mod warning;
 
+/// Convenience items for build scripts.
+pub mod convenience;
+
 #[cfg(test)]
 fn capture_output<F>(f: F) -> String
 where


### PR DESCRIPTION
Started working on `compare_and_set_contents_hash` that would allow one to avoid rerunning the build script if the *hashes* of the files change, rather than their modification time. In my case,

I found the need for this method when building a frontend for a `wry` application. The command `npm i` changes the modification time of `package-lock.json` even if the contents of the file remain the same.

The provided implementation supports only files, not the directories, yet this limitation is the result of my laziness rather than technical barriers.